### PR TITLE
Fix a bug in creating final URL that involved removing the double slash breaking the link.

### DIFF
--- a/Telegraph/Telegraph/TelegraphClient.cs
+++ b/Telegraph/Telegraph/TelegraphClient.cs
@@ -386,7 +386,7 @@ namespace Kvyk.Telegraph
                 telegraphFiles = list.Select(v => new TelegraphFile
                 {
                     Path = v.Src,
-                    Link = (Constants.TELEGPAPH + v.Src).Replace("//", "/"),
+                    Link = (Constants.TELEGPAPH + v.Src[1..])
                 }).ToList();
             }
 


### PR DESCRIPTION
Fixes #4 

Telegraph file test passed successfully. 